### PR TITLE
Fix macOS/Linux command by adding remote flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ The Manager app will:
 **macOS / Linux:**
 
 ```bash
-curl -sfL https://raw.githubusercontent.com/yashas-salankimatt/ZenLeap/main/install.sh | bash
+curl -sfL https://raw.githubusercontent.com/yashas-salankimatt/ZenLeap/main/install.sh | bash -s -- install --remote
 ```
 
 **Windows (PowerShell):**


### PR DESCRIPTION
The original command

```bash
curl -sfL https://raw.githubusercontent.com/yashas-salankimatt/ZenLeap/main/install.sh | bash
```

will check the folder `JS/zenleap.uc.js` locally. But since the scripted is piped with `curl`, there is no such local folder. This leads to such error:

```text
--- Default (release) ---
Installing ZenLeap...
Error: zenleap.uc.js not found
```

By adding the remote flag, `curl` will download those external files from GitHub, and this fixes the command line.

```bash
curl -sfL https://raw.githubusercontent.com/yashas-salankimatt/ZenLeap/main/install.sh | bash -s -- install --remote
```